### PR TITLE
Gpu memory

### DIFF
--- a/conceptnet_sme/relations.py
+++ b/conceptnet_sme/relations.py
@@ -23,6 +23,7 @@ ALL_RELATIONS = [
     "/r/Desires",
     "/r/DistinctFrom",
     "/r/Entails",
+    "/r/EtymologicallyDerivedFrom",
     "/r/EtymologicallyRelatedTo",
     "/r/ExternalURL",
     "/r/FormOf",

--- a/conceptnet_sme/semantic_matching.py
+++ b/conceptnet_sme/semantic_matching.py
@@ -4,13 +4,13 @@ import torch
 # multiple GPUs (if available; setting it True when there are no or only one
 # GPU won't hurt, but it won't help either).
 
-USE_MULTIPLE_GPUS = False
+USE_MULTIPLE_GPUS = True
 
 # Set NUM_BATCH_WORKERS > 0 to enable parallelization of generation of training
 # batches over multiple CPU cores (by spawning that number of worker processes;
 # 10 is a reasonable choice if you have multiple CPUs).
 
-NUM_BATCH_WORKERS = 0
+NUM_BATCH_WORKERS = 10
 if NUM_BATCH_WORKERS > 0:
     try:
         torch.multiprocessing.set_start_method("spawn")

--- a/conceptnet_sme/semantic_matching.py
+++ b/conceptnet_sme/semantic_matching.py
@@ -28,7 +28,7 @@ from conceptnet5.vectors.transforms import l2_normalize_rows
 
 RELATION_INDEX = pd.Index(COMMON_RELATIONS)
 N_RELS = len(RELATION_INDEX)
-INITIAL_VECS_FILENAME = get_data_filename('vectors/numberbatch-propagated.h5')
+INITIAL_VECS_FILENAME = get_data_filename('vectors/numberbatch-biased.h5')
 EDGES_FILENAME = get_data_filename('collated/sorted/edges-shuf.csv')
 MODEL_FILENAME = get_data_filename('sme/sme.model')
 NEG_SAMPLES = 5

--- a/conceptnet_sme/semantic_matching.py
+++ b/conceptnet_sme/semantic_matching.py
@@ -38,7 +38,7 @@ LANGUAGES_TO_USE = [
     'en', 'fr', 'de', 'it', 'es', 'ru', 'pt', 'ja', 'zh', 'nl',
     'ar', 'fa', 'ko', 'ms', 'no', 'pl', 'sv', 'mul'
 ]
-BATCH_SIZE=128
+BATCH_SIZE=160
 
 random.seed(0)
 


### PR DESCRIPTION
Changed nn.Embeddings to used sparse tensors to store their parameter gradients.  This enables use of much larger embeddings before running out of gpu memory, but means full weight-decay cannot be supported (and to support weight decay restricted to the part of the embedding parameters with non-zero gradients for a given training batch the sgd optimizer had to be replaced with a customized version).

To avoid running out of gpu memory when loading large saved models from disk, models are now moved to cpu memory before saving, and loaded into cpu memory before being moved to gpu.

There are a few additional tweaks (e.g. fixing the list of relations similarly to recent changes to conceptnet, moving saved loss data to the cpu, making batches returned via the dataloader tensors rather than variables).